### PR TITLE
Fix extend compaction bug and ensure tests import package

### DIFF
--- a/kll_sketch/kll_sketch.py
+++ b/kll_sketch/kll_sketch.py
@@ -70,12 +70,14 @@ class KLL:
             self._compress_until_ok()
 
     def extend(self, xs: Iterable[float]) -> None:
-        buf = self._levels[0]
         for x in xs:
             xv = float(x)
             if math.isnan(xv) or math.isinf(xv):
                 raise ValueError("values must be finite")
-            buf.append(xv)
+            # ``self._levels[0]`` can be replaced during compaction, so we must
+            # append directly to the current buffer each iteration instead of
+            # keeping a stale reference (which would silently drop values).
+            self._levels[0].append(xv)
             self._n += 1
             if self._capacity_exceeded():
                 self._compress_until_ok()

--- a/kll_sketch/tests/conftest.py
+++ b/kll_sketch/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration ensuring the package is importable during tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# When pytest collects tests inside the installed package directory, the
+# repository root (which contains the ``kll_sketch`` package) might not be on
+# ``sys.path``.  Add it explicitly so ``from kll_sketch import KLL`` works even
+# when the tests are executed without installing the project as a package.
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- ensure `KLL.extend` always appends to the active level-0 buffer so values aren’t lost when compaction replaces the list
- add a `tests/conftest.py` shim that puts the repository root on `sys.path` so `from kll_sketch import KLL` works during test collection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e00307ca0c8333b9a864379301dd7b