### PR TITLE
Improve KLL quantile queries with batched API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Fast, mergeable **KLL** sketch for streaming quantiles — deterministic, zero d
 - **Weighted ingestion** via `add(x, weight)` for aggregated data
 - **Mergeable** sketches for distributed/parallel ingestion
 - **Serializable** (`to_bytes` / `from_bytes`)
-- **Convenience helpers** such as `quantiles(m)` for evenly spaced cuts
+- **Convenience helpers** such as `quantiles(m)` and `quantiles_at(qs)` for
+  evenly spaced or ad-hoc cuts
 - **Zero dependencies**, Python 3.9+
 
 ---
@@ -60,6 +61,7 @@ assert abs(a2.quantile(0.5) - a.quantile(0.5)) < 1e-12
 | `size()`                      | Total number of ingested items `n`.     |
 | `quantile(q)`                 | Approximate `q`-quantile for `q∈[0,1]`. |
 | `quantiles(m)`                | Evenly spaced cut points.               |
+| `quantiles_at(qs)`            | Batched quantiles for arbitrary `qs`.   |
 | `median()`                    | Convenience for `quantile(0.5)`.        |
 | `rank(x)`                     | Approximate rank of `x` in `[0, n]`.    |
 | `cdf(xs)`                     | CDF values for a sequence `xs`.         |
@@ -81,6 +83,7 @@ This implementation follows **Karnin–Lang–Liberty (2016)**: a space-optimal 
 * Typical error ≈ **O(1/k)** in rank space (increase `capacity` to tighten ε).
 * Updates amortized **O(1)** with occasional compactions.
 * Queries merge level buffers (**k-way**) and scan weights to the target rank.
+  Use `quantiles_at` to answer multiple quantiles with a single scan.
 
 > Tip: For heavy query loads, cache materialized arrays between queries.
 

--- a/kll_sketch/tests/test_kll.py
+++ b/kll_sketch/tests/test_kll.py
@@ -206,3 +206,27 @@ def test_quantiles_helper_even_spacing() -> None:
 
     median_only = sketch.quantiles(1)
     assert median_only == pytest.approx([sketch.median()])
+
+
+def test_quantiles_at_matches_repeated_calls() -> None:
+    rng = random.Random(123)
+    xs = [rng.gauss(0.0, 2.0) for _ in range(5000)]
+
+    sketch = KLL(capacity=200)
+    sketch.extend(xs)
+
+    qs = [0.05, 0.2, 0.33, 0.5, 0.75, 0.95]
+    batched = sketch.quantiles_at(qs)
+    repeated = [sketch.quantile(q) for q in qs]
+    assert batched == pytest.approx(repeated, abs=1e-12)
+
+
+def test_quantiles_at_accepts_unsorted_probabilities() -> None:
+    sketch = KLL(capacity=128)
+    sketch.extend(range(1000))
+
+    qs = [0.9, 0.1, 0.5]
+    values = sketch.quantiles_at(qs)
+    assert values[0] == pytest.approx(sketch.quantile(0.9))
+    assert values[1] == pytest.approx(sketch.quantile(0.1))
+    assert values[2] == pytest.approx(sketch.quantile(0.5))


### PR DESCRIPTION
## Summary
- add a quantiles_at helper that answers multiple quantile queries from one materialization pass
- refactor quantile/quantiles to share a batched implementation and document the new API
- cover the new behaviour with deterministic regression tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d42d513883339482bf891d5dc324