### PR TITLE
Install test extras in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: python -m pip install --upgrade pip pytest
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install "./kll_sketch[test]"
       - run: python -m pytest -q


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions workflow installs the project's test extras so pytest-cov is available during CI runs

## Testing
- python -m pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5007d3a448333bad1aa04c54a1138