### PR TITLE
Add Codecov upload step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,7 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install --upgrade pip pytest
       - run: python -m pytest -q
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- add a Codecov upload step to the CI workflow after running pytest

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e505a933a48333a543a8dbde851902