### PR TITLE
Fix CI pipeline to publish coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: python -m pip install --upgrade pip pytest
-      - run: python -m pytest -q
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r kll_sketch/requirements-test.txt
+      - name: Run tests with coverage
+        run: python -m pytest --cov=kll_sketch --cov-report=term-missing --cov-report=xml kll_sketch/tests
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/kll_sketch/pyproject.toml
+++ b/kll_sketch/pyproject.toml
@@ -33,7 +33,7 @@ test = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--strict-config --strict-markers --cov=kll_sketch --cov-report=term-missing"
+addopts = "--strict-config --strict-markers --cov=kll_sketch --cov-report=term-missing --cov-report=xml"
 testpaths = ["kll_sketch/tests"]
 filterwarnings = [
   "error",


### PR DESCRIPTION
## Summary
- install the project test dependencies in CI before executing the suite
- run pytest with coverage reporting enabled so that Codecov can find coverage data
- emit an XML coverage report by default so the Codecov uploader succeeds

## Testing
- python -m pytest --cov=kll_sketch --cov-report=term-missing --cov-report=xml kll_sketch/tests *(fails: pytest-cov missing in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5073f9fa883338abe05f8991012d8