### PR TITLE
Add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Here’s a polished, stars-friendly **README.md** you can paste on your repo’s
 Fast, mergeable **KLL** sketch for streaming quantiles — deterministic, zero deps, production-ready.
 
 [![CI](https://github.com/SaridakisStamatisChristos/kll_sketch/actions/workflows/ci.yml/badge.svg)](https://github.com/SaridakisStamatisChristos/kll_sketch/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/SaridakisStamatisChristos/kll_sketch/branch/main/graph/badge.svg)](https://codecov.io/gh/SaridakisStamatisChristos/kll_sketch)
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- add a Codecov coverage badge to the README alongside the existing CI badge

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e50fdca60c833393b2326ff428ec71