### PR TITLE
Refine benchmark tooling and add CI smoke run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,31 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  bench:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install bench extras
+        working-directory: kll_sketch
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[bench]
+      - name: Run smoke benchmark
+        working-directory: kll_sketch
+        run: |
+          python benchmarks/bench_kll.py \
+            --outdir bench_out \
+            --Ns 1e5 \
+            --capacities 200 \
+            --distributions normal \
+            --qs 0.25 0.5 0.75 \
+            --shards 4
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-out
+          path: kll_sketch/bench_out

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bench_out/

--- a/README.md
+++ b/README.md
@@ -101,6 +101,38 @@ python -m pytest -q
 
 ---
 
+## 📈 Benchmarks
+
+Get the optional tooling with extras:
+
+```bash
+python -m pip install -e .[bench,test]
+```
+
+Run the full synthetic sweep (matching the defaults in the docs):
+
+```bash
+python benchmarks/bench_kll.py \
+  --module kll_sketch --class KLLSketch \
+  --outdir bench_out \
+  --Ns 1e5 1e6 \
+  --capacities 200 400 800 \
+  --distributions uniform normal exponential pareto bimodal \
+  --qs 0.01 0.05 0.1 0.25 0.5 0.75 0.9 0.95 0.99 \
+  --shards 8
+```
+
+Artifacts land in `bench_out/` with the following schema:
+
+- `accuracy.csv` — distribution, `N`, capacity, mode (`single`/`merged`), quantile, estimate, exact, and absolute value error.
+- `update_throughput.csv` — distribution, `N`, capacity, update wall time (seconds), and computed inserts/sec.
+- `query_latency.csv` — distribution, `N`, capacity, quantile, and per-query latency in microseconds.
+- `merge.csv` — distribution, `N`, capacity, shard count, and merge wall time (seconds).
+
+Visualise the outputs via `benchmarks/bench_plots.ipynb`, and read [`docs/benchmarks.md`](docs/benchmarks.md) for a narrated walkthrough.
+
+---
+
 ## 🗺️ Roadmap
 
 * Optional NumPy/C hot paths for sort/merge.

--- a/benchmarks/bench_kll.py
+++ b/benchmarks/bench_kll.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Benchmark runner for the local kll_sketch implementation."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import hashlib
+import math
+import time
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--module", default="kll_sketch", help="Module that exports the sketch class")
+    parser.add_argument("--class", dest="cls", default="KLLSketch", help="Sketch class name inside the module")
+    parser.add_argument("--outdir", default="bench_out", help="Directory for benchmark CSV outputs")
+    parser.add_argument("--seed", type=int, default=42, help="Base RNG seed for reproducibility")
+    parser.add_argument("--Ns", nargs="+", default=["1e5", "1e6"], help="Population sizes to benchmark")
+    parser.add_argument(
+        "--capacities", nargs="+", default=["200", "400", "800"], help="Sketch capacities to benchmark"
+    )
+    parser.add_argument(
+        "--distributions",
+        nargs="+",
+        default=["uniform", "normal", "exponential", "pareto", "bimodal"],
+        help="Synthetic data distributions to sample",
+    )
+    parser.add_argument(
+        "--qs",
+        nargs="+",
+        default=["0.01", "0.05", "0.1", "0.25", "0.5", "0.75", "0.9", "0.95", "0.99"],
+        help="Quantiles to evaluate",
+    )
+    parser.add_argument("--shards", type=int, default=8, help="Number of shards for the merge benchmark")
+    return parser.parse_args()
+
+
+def _to_int_list(values: Iterable[str]) -> List[int]:
+    return [int(float(v)) for v in values]
+
+
+def _to_float_list(values: Iterable[str]) -> List[float]:
+    return [float(v) for v in values]
+
+
+def _hash_seed(seed: int, *parts: object) -> int:
+    material = "::".join(str(p) for p in (seed,) + parts)
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return int(digest[:16], 16)
+
+
+def _uniform(rng: np.random.Generator, size: int) -> np.ndarray:
+    return rng.uniform(0.0, 1.0, size)
+
+
+def _normal(rng: np.random.Generator, size: int) -> np.ndarray:
+    return rng.normal(0.0, 1.0, size)
+
+
+def _exponential(rng: np.random.Generator, size: int) -> np.ndarray:
+    return rng.exponential(scale=1.0, size=size)
+
+
+def _pareto(rng: np.random.Generator, size: int) -> np.ndarray:
+    return rng.pareto(a=1.5, size=size)
+
+
+def _bimodal(rng: np.random.Generator, size: int) -> np.ndarray:
+    left = size // 2
+    right = size - left
+    first = rng.normal(-2.0, 1.0, left)
+    second = rng.normal(2.0, 0.5, right)
+    data = np.concatenate([first, second]) if size else np.empty(0, dtype=float)
+    rng.shuffle(data)
+    return data
+
+
+DATA_GENERATORS: Dict[str, Callable[[np.random.Generator, int], np.ndarray]] = {
+    "uniform": _uniform,
+    "normal": _normal,
+    "exponential": _exponential,
+    "pareto": _pareto,
+    "bimodal": _bimodal,
+}
+
+
+def _validate_distributions(names: Sequence[str]) -> None:
+    unknown = sorted(set(names) - DATA_GENERATORS.keys())
+    if unknown:
+        raise ValueError(f"Unknown distributions requested: {', '.join(unknown)}")
+
+
+def _instantiate_sketch(sketch_cls, capacity: int, seed: int):
+    try:
+        return sketch_cls(capacity=capacity, rng_seed=seed)
+    except TypeError:
+        # Older signatures might use positional arguments only.
+        return sketch_cls(capacity)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    Ns = _to_int_list(args.Ns)
+    capacities = _to_int_list(args.capacities)
+    qs = _to_float_list(args.qs)
+    _validate_distributions(args.distributions)
+
+    module = importlib.import_module(args.module)
+    cls_name = args.cls
+    if not hasattr(module, cls_name):
+        fallback_names = []
+        if not cls_name.endswith("Sketch"):
+            fallback_names.append(f"{cls_name}Sketch")
+        fallback_names.append("KLLSketch")
+        for candidate in fallback_names:
+            if hasattr(module, candidate):
+                cls_name = candidate
+                break
+        else:
+            available = ", ".join(sorted(attr for attr in dir(module) if not attr.startswith("_")))
+            raise AttributeError(
+                f"{module.__name__!r} does not define {args.cls!r}. Available attributes: {available}"
+            )
+
+    sketch_cls = getattr(module, cls_name)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    accuracy_records: List[Dict[str, object]] = []
+    throughput_records: List[Dict[str, object]] = []
+    latency_records: List[Dict[str, object]] = []
+    merge_records: List[Dict[str, object]] = []
+
+    for dist in args.distributions:
+        for N in Ns:
+            combo_seed = _hash_seed(args.seed, dist, N)
+            data_rng = np.random.default_rng(combo_seed)
+            generator = DATA_GENERATORS[dist]
+            data = generator(data_rng, N).astype(float, copy=False)
+            if data.size != N:
+                data = np.resize(data, N)
+
+            exact_quantiles = np.quantile(data, qs, method="linear")
+            exact_map = dict(zip(qs, exact_quantiles))
+
+            for capacity in capacities:
+                sketch = _instantiate_sketch(sketch_cls, capacity, args.seed)
+                start = time.perf_counter()
+                for value in data:
+                    sketch.add(float(value))
+                update_elapsed = time.perf_counter() - start
+                updates_per_sec = (N / update_elapsed) if update_elapsed > 0 else math.inf
+
+                throughput_records.append(
+                    {
+                        "distribution": dist,
+                        "N": int(N),
+                        "capacity": int(capacity),
+                        "update_time_s": update_elapsed,
+                        "updates_per_sec": updates_per_sec,
+                    }
+                )
+
+                for q in qs:
+                    q_float = float(q)
+                    q_start = time.perf_counter()
+                    approx = sketch.quantile(q_float)
+                    q_elapsed = time.perf_counter() - q_start
+                    latency_records.append(
+                        {
+                            "distribution": dist,
+                            "N": int(N),
+                            "capacity": int(capacity),
+                            "q": q_float,
+                            "latency_us": q_elapsed * 1e6,
+                        }
+                    )
+                    accuracy_records.append(
+                        {
+                            "distribution": dist,
+                            "N": int(N),
+                            "capacity": int(capacity),
+                            "mode": "single",
+                            "q": q_float,
+                            "estimate": approx,
+                            "exact": exact_map[q_float],
+                            "abs_error": abs(approx - exact_map[q_float]),
+                        }
+                    )
+
+                shard_arrays = np.array_split(data, args.shards)
+                shard_sketches = []
+                for shard_idx, shard in enumerate(shard_arrays):
+                    shard_sketch = _instantiate_sketch(
+                        sketch_cls, capacity, args.seed + shard_idx + 1
+                    )
+                    for value in shard:
+                        shard_sketch.add(float(value))
+                    shard_sketches.append(shard_sketch)
+
+                merge_target = _instantiate_sketch(sketch_cls, capacity, args.seed)
+                merge_start = time.perf_counter()
+                for shard_sketch in shard_sketches:
+                    merge_target.merge(shard_sketch)
+                merge_elapsed = time.perf_counter() - merge_start
+
+                merge_records.append(
+                    {
+                        "distribution": dist,
+                        "N": int(N),
+                        "capacity": int(capacity),
+                        "shards": int(args.shards),
+                        "merge_time_s": merge_elapsed,
+                    }
+                )
+
+                for q in qs:
+                    q_float = float(q)
+                    approx = merge_target.quantile(q_float)
+                    accuracy_records.append(
+                        {
+                            "distribution": dist,
+                            "N": int(N),
+                            "capacity": int(capacity),
+                            "mode": "merged",
+                            "q": q_float,
+                            "estimate": approx,
+                            "exact": exact_map[q_float],
+                            "abs_error": abs(approx - exact_map[q_float]),
+                        }
+                    )
+
+    accuracy_path = outdir / "accuracy.csv"
+    throughput_path = outdir / "update_throughput.csv"
+    latency_path = outdir / "query_latency.csv"
+    merge_path = outdir / "merge.csv"
+
+    pd.DataFrame.from_records(accuracy_records).to_csv(accuracy_path, index=False)
+    pd.DataFrame.from_records(throughput_records).to_csv(throughput_path, index=False)
+    pd.DataFrame.from_records(latency_records).to_csv(latency_path, index=False)
+    pd.DataFrame.from_records(merge_records).to_csv(merge_path, index=False)
+
+    print("Benchmark artifacts written to:")
+    print(f"  {accuracy_path}")
+    print(f"  {throughput_path}")
+    print(f"  {latency_path}")
+    print(f"  {merge_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_plots.ipynb
+++ b/benchmarks/bench_plots.ipynb
@@ -1,0 +1,169 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# KLL Sketch Benchmark Plots\n",
+        "\n",
+        "Load the CSV outputs from `benchmarks/bench_kll.py`, generate a few diagnostic plots, and summarise accuracy statistics.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "import math\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "from IPython.display import display\n",
+        "\n",
+        "plt.style.use('seaborn-v0_8-darkgrid')\n",
+        "outdir = Path('bench_out')\n",
+        "accuracy = pd.read_csv(outdir / 'accuracy.csv')\n",
+        "throughput = pd.read_csv(outdir / 'update_throughput.csv')\n",
+        "latency = pd.read_csv(outdir / 'query_latency.csv')\n",
+        "merge = pd.read_csv(outdir / 'merge.csv')\n",
+        "accuracy.head()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "single_accuracy = accuracy[accuracy['mode'] == 'single']\n",
+        "dists = sorted(single_accuracy['distribution'].unique())\n",
+        "cols = min(3, max(1, len(dists)))\n",
+        "rows = math.ceil(len(dists) / cols)\n",
+        "fig, axes = plt.subplots(rows, cols, figsize=(6 * cols, 4 * rows), sharex=True, sharey=True)\n",
+        "axes = np.array(axes, dtype=object).reshape(rows, cols)\n",
+        "for idx, dist in enumerate(dists):\n",
+        "    ax = axes[idx // cols, idx % cols]\n",
+        "    dist_data = single_accuracy[single_accuracy['distribution'] == dist]\n",
+        "    for capacity, cap_df in dist_data.groupby('capacity'):\n",
+        "        cap_df = cap_df.sort_values('q')\n",
+        "        ax.plot(cap_df['q'], cap_df['abs_error'], marker='o', label=f'K={capacity}')\n",
+        "    ax.set_title(dist)\n",
+        "    ax.set_xlabel('q')\n",
+        "    ax.set_ylabel('|error|')\n",
+        "    ax.legend()\n",
+        "for idx in range(len(dists), rows * cols):\n",
+        "    axes[idx // cols, idx % cols].axis('off')\n",
+        "plt.suptitle('Absolute value error by quantile (single pass)')\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots(figsize=(7, 4))\n",
+        "for capacity, cap_df in throughput.groupby('capacity'):\n",
+        "    cap_df = cap_df.sort_values('N')\n",
+        "    ax.plot(cap_df['N'], cap_df['updates_per_sec'], marker='o', label=f'K={capacity}')\n",
+        "ax.set_xscale('log')\n",
+        "ax.set_xlabel('N')\n",
+        "ax.set_ylabel('updates/sec')\n",
+        "ax.set_title('Update throughput by problem size')\n",
+        "ax.legend()\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots(figsize=(7, 4))\n",
+        "for q, q_df in latency.groupby('q'):\n",
+        "    q_df = q_df.sort_values('capacity')\n",
+        "    ax.plot(q_df['capacity'], q_df['latency_us'], marker='o', label=f'q={q}')\n",
+        "ax.set_xlabel('capacity')\n",
+        "ax.set_ylabel('latency (\u00b5s)')\n",
+        "ax.set_title('Query latency by quantile')\n",
+        "ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig, ax = plt.subplots(figsize=(7, 4))\n",
+        "for (dist, N), grp in merge.groupby(['distribution', 'N']):\n",
+        "    grp = grp.sort_values('shards')\n",
+        "    label = f'{dist}, N={N}'\n",
+        "    ax.plot(grp['shards'], grp['merge_time_s'], marker='o', label=label)\n",
+        "ax.set_xlabel('shards')\n",
+        "ax.set_ylabel('merge time (s)')\n",
+        "ax.set_title('Merge time vs shards')\n",
+        "ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "summary = (\n",
+        "    single_accuracy.groupby(['distribution', 'capacity'])\n",
+        "    .agg(mean_abs_error=('abs_error', 'mean'), median_abs_error=('abs_error', 'median'))\n",
+        "    .reset_index()\n",
+        ")\n",
+        "summary\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "best = (\n",
+        "    accuracy.sort_values('abs_error')\n",
+        "    .groupby(['distribution', 'capacity', 'mode'], as_index=False)\n",
+        "    .first()\n",
+        ")\n",
+        "worst = (\n",
+        "    accuracy.sort_values('abs_error', ascending=False)\n",
+        "    .groupby(['distribution', 'capacity', 'mode'], as_index=False)\n",
+        "    .first()\n",
+        ")\n",
+        "print('Best quantiles (lowest abs error):')\n",
+        "display(best[['distribution', 'capacity', 'mode', 'q', 'abs_error']])\n",
+        "print('\nWorst quantiles (highest abs error):')\n",
+        "display(worst[['distribution', 'capacity', 'mode', 'q', 'abs_error']])\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,90 @@
+# KLL Sketch Benchmarking Guide
+
+This guide explains how to generate baseline performance numbers for the local `kll_sketch` implementation, analyse the results, and interpret the reported error metrics.
+
+## Installation
+
+The benchmarks rely on a handful of scientific Python packages. Create and activate a virtual environment, then install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[bench]
+```
+
+> Windows PowerShell activation: `.venv\Scripts\Activate.ps1`
+
+If you prefer an ad-hoc install without extras, install the runtime packages manually: `pip install -U numpy pandas matplotlib pytest pytest-benchmark jupyter`.
+
+## Running the CLI benchmarks
+
+The entry point lives at `benchmarks/bench_kll.py`. It generates synthetic datasets, measures update throughput, query latency, accuracy against `numpy.quantile`, and merge performance. By default it sweeps the recommended population sizes, sketch capacities, quantiles, and distributions. All artifacts are written beneath `bench_out/`.
+
+Example command (matches the defaults):
+
+```bash
+python benchmarks/bench_kll.py \
+  --module kll_sketch --class KLLSketch \
+  --outdir bench_out \
+  --Ns 1e5 1e6 \
+  --capacities 200 400 800 \
+  --distributions uniform normal exponential pareto bimodal \
+  --qs 0.01 0.05 0.1 0.25 0.5 0.75 0.9 0.95 0.99 \
+  --shards 8
+```
+
+The script produces four CSV files:
+
+- `bench_out/accuracy.csv`: absolute value error for each `(distribution, N, capacity, q)` pair. A `mode` column distinguishes single-pass sketches from merged sketches.
+- `bench_out/update_throughput.csv`: update times and inserts/sec for each `(distribution, N, capacity)` combination.
+- `bench_out/query_latency.csv`: per-quantile latency measurements in microseconds.
+- `bench_out/merge.csv`: merge timings versus shard counts.
+
+## Pytest micro-benchmarks
+
+The micro-benchmarks live under `tests/bench/` and are marked with `@pytest.mark.benchmark` so they are skipped unless explicitly requested. They use `pytest-benchmark` to record update throughput for `N ∈ {1e5, 1e6}` and `capacity ∈ {200, 400, 800}` on uniform and normal data. A lightweight accuracy assertion verifies that the median absolute error stays within `~1%` of the data standard deviation to avoid flaky failures.
+
+Run them with:
+
+```bash
+pytest -m benchmark -q --benchmark-json=bench_out/pytest/results.json
+```
+
+The `bench_out/pytest/` directory is created automatically so the JSON export succeeds.
+
+## Plotting the results
+
+Open the Jupyter notebook at `benchmarks/bench_plots.ipynb` to load the CSV outputs, generate the summary plots, and inspect basic accuracy tables:
+
+```bash
+jupyter notebook benchmarks/bench_plots.ipynb
+```
+
+The notebook provides:
+
+- Absolute value error versus quantile, faceted by distribution with one line per capacity.
+- Updates/sec versus `N` on a log-scaled horizontal axis, grouped by capacity.
+- Query latency (µs) versus capacity, grouped by quantile.
+- Merge time versus the number of shards.
+- Summary tables for mean/median error and best/worst quantiles.
+
+## Interpreting the metrics
+
+- **Value error vs rank error**: The benchmark tracks *value* error—`|approximate_quantile - exact_quantile|`. This directly measures how far the returned value is from the true quantile. Rank error (difference between approximate and exact ranks) is another perspective, but is not reported here. Large value errors often occur in heavy-tailed regions even when rank error is acceptable.
+- **Capacity (`k`)**: The sketch capacity controls the maximum buffer size (and therefore the accuracy/memory trade-off). Higher capacities retain more samples, reducing approximation error at the cost of higher memory usage and slightly slower updates. You should observe smaller value errors as `k` increases, especially for central quantiles.
+- **Throughput and latency**: Updates/sec should scale roughly linearly with the input size until memory/cache effects kick in. Query latency (µs per quantile) should remain in the single digits to low tens for the provided capacities.
+- **Merge performance**: Shard merges should be significantly faster than building a sketch from scratch. Post-merge accuracy should match single-pass sketches within noise.
+
+## Repository layout
+
+```
+kll_sketch/
+├── benchmarks/
+│   ├── bench_kll.py        # CLI benchmark runner
+│   └── bench_plots.ipynb   # Notebook for plotting CSV outputs
+├── tests/
+│   └── bench/              # Pytest micro-benchmarks (marked)
+├── bench_out/              # Outputs (ignored by git)
+└── docs/
+    └── benchmarks.md       # This guide
+```

--- a/kll_sketch/__init__.py
+++ b/kll_sketch/__init__.py
@@ -1,4 +1,9 @@
 # kll_sketch/__init__.py
 from .kll_sketch import KLL
 
-__all__ = ["KLL"]
+
+class KLLSketch(KLL):
+    """Alias for :class:`KLL` used by the benchmarking utilities."""
+
+
+__all__ = ["KLL", "KLLSketch"]

--- a/kll_sketch/pyproject.toml
+++ b/kll_sketch/pyproject.toml
@@ -26,6 +26,13 @@ Homepage = "https://github.com/yourname/kll_sketch"
 Repository = "https://github.com/yourname/kll_sketch"
 
 [project.optional-dependencies]
+bench = [
+  "numpy>=1.22",
+  "pandas>=2.0",
+  "matplotlib>=3.7",
+  "pytest-benchmark>=4.0",
+  "jupyter",
+]
 test = [
   "pytest>=7.4",
   "hypothesis>=6.88",
@@ -34,7 +41,10 @@ test = [
 
 [tool.pytest.ini_options]
 addopts = "--strict-config --strict-markers --cov=kll_sketch --cov-report=term-missing --cov-report=xml"
-testpaths = ["kll_sketch/tests"]
+testpaths = ["kll_sketch/tests", "tests"]
+markers = [
+  "benchmark: performance benchmarks (opt-in)",
+]
 filterwarnings = [
   "error",
 ]

--- a/tests/bench/conftest.py
+++ b/tests/bench/conftest.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Ensure the default pytest-benchmark output directory exists when users
+    # pass ``--benchmark-json=bench_out/pytest/results.json``.
+    Path("bench_out/pytest").mkdir(parents=True, exist_ok=True)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    marker_expr = config.getoption("-m")
+    if marker_expr:
+        # Users explicitly requested a marker expression; respect it.
+        return
+    skip_marker = pytest.mark.skip(reason="benchmark tests are opt-in; run with -m benchmark")
+    for item in items:
+        if "benchmark" in item.keywords:
+            item.add_marker(skip_marker)

--- a/tests/bench/test_benchmarks.py
+++ b/tests/bench/test_benchmarks.py
@@ -1,0 +1,48 @@
+"""Pytest micro-benchmarks for the KLL sketch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy")
+import numpy as np
+
+from kll_sketch import KLLSketch
+
+OUTPUT_DIR = Path("bench_out/pytest")
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+pytestmark = pytest.mark.benchmark
+
+
+def _generate_data(dist: str, size: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    if dist == "uniform":
+        return rng.uniform(0.0, 1.0, size)
+    if dist == "normal":
+        return rng.normal(0.0, 1.0, size)
+    raise ValueError(f"Unsupported distribution for pytest benchmarks: {dist}")
+
+
+@pytest.mark.parametrize("distribution", ["uniform", "normal"])
+@pytest.mark.parametrize("N", [int(1e5), int(1e6)])
+@pytest.mark.parametrize("capacity", [200, 400, 800])
+def test_update_throughput(distribution: str, N: int, capacity: int, benchmark) -> None:
+    data = _generate_data(distribution, N, seed=42)
+
+    def build_sketch() -> KLLSketch:
+        sketch = KLLSketch(capacity=capacity, rng_seed=42)
+        for value in data:
+            sketch.add(float(value))
+        return sketch
+
+    sketch = benchmark(build_sketch)
+
+    approx = sketch.quantile(0.5)
+    exact = float(np.quantile(data, 0.5))
+    std = float(np.std(data))
+    scale = 0.02 * std * (200 / capacity) ** 0.5 if std > 0 else 0.0
+    tolerance = max(1e-9, scale)
+    assert abs(approx - exact) <= tolerance


### PR DESCRIPTION
## Summary
- ensure the benchmark CLI pins NumPy quantiles and gracefully resolves --class values
- add a "bench" extra with documentation updates and make the pytest accuracy guard capacity-aware
- run a lightweight benchmark smoke test in CI and publish its artifacts

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5159c6f408333889e74485d9179dc